### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The repo contains a set of applications for Kubernetes that simulate a working p
 
 1) You need a New Relic account and license key. You can create one on https://newrelic.com/signup
 
-2) Deploy a Kubernetes secret with your New Relic license key: `kubectl create secret generic newrelic-license-key --from-literal=license='[[NEW RELIC LICENSE KEY]]'` ( BrettW: previously, this key had the wrong name ) 
+2) Deploy a Kubernetes secret with your New Relic license key: `kubectl create secret generic newrelic-license-key --from-literal=license='[[NEW RELIC LICENSE KEY]]'` 
 
 3) Deploy the applications on a Kubernetes cluster with `kubectl apply -f yaml/`
 


### PR DESCRIPTION
error from pod:

kubelet            Error: secret "newrelic-license-key" not found

This fix is for fixing secret key name in the readme to match frontend deployment manifest.

env:
        - name: NEW_RELIC_LICENSE_KEY
          valueFrom:
            secretKeyRef:
              name: newrelic-license-key